### PR TITLE
Add cache invalidation with file watcher

### DIFF
--- a/src/main/kotlin/com/github/pyvenvmanage/VenvProjectViewNodeDecorator.kt
+++ b/src/main/kotlin/com/github/pyvenvmanage/VenvProjectViewNodeDecorator.kt
@@ -1,7 +1,5 @@
 package com.github.pyvenvmanage
 
-import java.util.concurrent.ConcurrentHashMap
-
 import com.intellij.ide.projectView.PresentationData
 import com.intellij.ide.projectView.ProjectViewNode
 import com.intellij.ide.projectView.ProjectViewNodeDecorator
@@ -10,17 +8,12 @@ import com.intellij.ui.SimpleTextAttributes
 import com.jetbrains.python.icons.PythonIcons.Python.Virtualenv
 
 class VenvProjectViewNodeDecorator : ProjectViewNodeDecorator {
-    private val versionCache = ConcurrentHashMap<String, String?>()
-
     override fun decorate(
         node: ProjectViewNode<*>,
         data: PresentationData,
     ) {
         VenvUtils.getPyVenvCfg(node.virtualFile)?.let { pyVenvCfgPath ->
-            val pythonVersion =
-                versionCache.computeIfAbsent(pyVenvCfgPath.toString()) {
-                    VenvUtils.getPythonVersionFromPyVenv(pyVenvCfgPath)
-                }
+            val pythonVersion = VenvVersionCache.getInstance().getVersion(pyVenvCfgPath.toString())
             pythonVersion?.let { version ->
                 data.presentableText?.let { fileName ->
                     data.clearText()

--- a/src/main/kotlin/com/github/pyvenvmanage/VenvVersionCache.kt
+++ b/src/main/kotlin/com/github/pyvenvmanage/VenvVersionCache.kt
@@ -1,0 +1,65 @@
+package com.github.pyvenvmanage
+
+import java.util.concurrent.ConcurrentHashMap
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.vfs.AsyncFileListener
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
+
+@Service(Service.Level.APP)
+class VenvVersionCache : Disposable {
+    private val cache = ConcurrentHashMap<String, String?>()
+
+    init {
+        VirtualFileManager.getInstance().addAsyncFileListener(
+            { events ->
+                val pyvenvChanges =
+                    events.filter { event ->
+                        val path = event.path
+                        path.endsWith("pyvenv.cfg") &&
+                            (event is VFileContentChangeEvent || event is VFileDeleteEvent)
+                    }
+                if (pyvenvChanges.isNotEmpty()) {
+                    object : AsyncFileListener.ChangeApplier {
+                        override fun afterVfsChange() {
+                            pyvenvChanges.forEach { event ->
+                                invalidate(event.path)
+                            }
+                        }
+                    }
+                } else {
+                    null
+                }
+            },
+            this,
+        )
+    }
+
+    fun getVersion(pyvenvCfgPath: String): String? =
+        cache.computeIfAbsent(pyvenvCfgPath) {
+            VenvUtils.getPythonVersionFromPyVenv(
+                java.nio.file.Path
+                    .of(it),
+            )
+        }
+
+    fun invalidate(path: String) {
+        cache.remove(path)
+    }
+
+    fun clear() {
+        cache.clear()
+    }
+
+    override fun dispose() {
+        cache.clear()
+    }
+
+    companion object {
+        fun getInstance(): VenvVersionCache = service()
+    }
+}

--- a/src/test/kotlin/com/github/pyvenvmanage/VenvUtilsVersionTest.kt
+++ b/src/test/kotlin/com/github/pyvenvmanage/VenvUtilsVersionTest.kt
@@ -1,0 +1,74 @@
+package com.github.pyvenvmanage
+
+import java.nio.file.Files
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Tests for VenvUtils.getPythonVersionFromPyVenv
+ * VenvVersionCache is tested via UI tests since it requires IntelliJ Application context
+ */
+class VenvUtilsVersionTest {
+    @TempDir
+    lateinit var tempDir: java.nio.file.Path
+
+    @Test
+    fun `getPythonVersionFromPyVenv returns version from pyvenv cfg`() {
+        val pyvenvCfg = tempDir.resolve("pyvenv.cfg")
+        Files.writeString(pyvenvCfg, "version = 3.11.5\nhome = /usr/bin")
+
+        val version = VenvUtils.getPythonVersionFromPyVenv(pyvenvCfg)
+
+        assertEquals("3.11.5", version)
+    }
+
+    @Test
+    fun `getPythonVersionFromPyVenv trims whitespace`() {
+        val pyvenvCfg = tempDir.resolve("pyvenv.cfg")
+        Files.writeString(pyvenvCfg, "version =   3.11.5   \nhome = /usr/bin")
+
+        val version = VenvUtils.getPythonVersionFromPyVenv(pyvenvCfg)
+
+        assertEquals("3.11.5", version)
+    }
+
+    @Test
+    fun `getPythonVersionFromPyVenv returns null for missing file`() {
+        val pyvenvCfg = tempDir.resolve("nonexistent").resolve("pyvenv.cfg")
+
+        val version = VenvUtils.getPythonVersionFromPyVenv(pyvenvCfg)
+
+        assertNull(version)
+    }
+
+    @Test
+    fun `getPythonVersionFromPyVenv returns null for file without version`() {
+        val pyvenvCfg = tempDir.resolve("pyvenv.cfg")
+        Files.writeString(pyvenvCfg, "home = /usr/bin\ninclude-system-site-packages = false")
+
+        val version = VenvUtils.getPythonVersionFromPyVenv(pyvenvCfg)
+
+        assertNull(version)
+    }
+
+    @Test
+    fun `getPythonVersionFromPyVenv handles complex pyvenv cfg`() {
+        val pyvenvCfg = tempDir.resolve("pyvenv.cfg")
+        Files.writeString(
+            pyvenvCfg,
+            """
+            home = /usr/local/bin
+            include-system-site-packages = false
+            version = 3.12.0
+            executable = /usr/local/bin/python3.12
+            """.trimIndent(),
+        )
+
+        val version = VenvUtils.getPythonVersionFromPyVenv(pyvenvCfg)
+
+        assertEquals("3.12.0", version)
+    }
+}


### PR DESCRIPTION
- Add VenvVersionCache application-level service with AsyncFileListener
- Automatically invalidate cached Python versions when pyvenv.cfg files change or are deleted
- Update VenvProjectViewNodeDecorator to use the new cache service
- Add unit tests for version parsing
- Update decorator tests to mock the cache service

This replaces the previous in-class ConcurrentHashMap caching with a proper service that can respond to file system changes.

## Test plan

- [x] Unit tests pass
- [ ] UI tests pass in CI
- [ ] Verify version display updates when pyvenv.cfg is modified