### PR TITLE
Improve error UX with notifications

### DIFF
--- a/src/main/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionModule.kt
+++ b/src/main/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionModule.kt
@@ -11,9 +11,11 @@ class ConfigurePythonActionModule : ConfigurePythonActionAbstract() {
         project: Project,
         selectedPath: VirtualFile,
         sdk: Sdk,
-    ): String? {
-        val module = ProjectFileIndex.getInstance(project).getModuleForFile(selectedPath, false) ?: return null
+    ): SetSdkResult {
+        val module =
+            ProjectFileIndex.getInstance(project).getModuleForFile(selectedPath, false)
+                ?: return SetSdkResult.Error("No module found for ${selectedPath.name}")
         ModuleRootModificationUtil.setModuleSdk(module, sdk)
-        return "module ${module.name}"
+        return SetSdkResult.Success("module ${module.name}")
     }
 }

--- a/src/main/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionProject.kt
+++ b/src/main/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionProject.kt
@@ -10,8 +10,8 @@ class ConfigurePythonActionProject : ConfigurePythonActionAbstract() {
         project: Project,
         selectedPath: VirtualFile,
         sdk: Sdk,
-    ): String {
+    ): SetSdkResult {
         SdkConfigurationUtil.setDirectoryProjectSdk(project, sdk)
-        return "project ${project.name}"
+        return SetSdkResult.Success("project ${project.name}")
     }
 }


### PR DESCRIPTION
- Add error notifications when Python executable not found
- Add error notifications when SDK creation fails
- Add error notifications when module not found (for module-level setting)
- Refactor to use sealed class SetSdkResult for type-safe error handling
- Show clear error messages to help users understand failures

Previously, when operations failed the actions would silently return without any feedback to the user. Now users get clear error notifications explaining what went wrong.

## Test plan

- [ ] Verify error notification appears when trying to set interpreter from non-venv directory
- [ ] Verify error notification appears when SDK creation fails
- [ ] Verify error notification appears when setting module interpreter outside any module