### PR TITLE
Make Python dependency optional to fix marketplace verification

### DIFF
--- a/src/main/kotlin/com/github/pyvenvmanage/PythonRequiredStartupActivity.kt
+++ b/src/main/kotlin/com/github/pyvenvmanage/PythonRequiredStartupActivity.kt
@@ -1,0 +1,40 @@
+package com.github.pyvenvmanage
+
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+import com.github.pyvenvmanage.settings.PyVenvManageSettings
+
+class PythonRequiredStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        if (isPythonPluginAvailable()) return
+        if (PyVenvManageSettings.getInstance().dismissedPythonWarning) return
+        NotificationGroupManager
+            .getInstance()
+            .getNotificationGroup("PyVenv Manage")
+            .createNotification(
+                "PyVenv Manage requires Python support",
+                "Please install the Python plugin or use PyCharm for full functionality.",
+                NotificationType.WARNING,
+            ).addAction(
+                NotificationAction.createExpiring("Don't show again") { _, notification ->
+                    PyVenvManageSettings.getInstance().dismissedPythonWarning = true
+                    notification.expire()
+                },
+            ).notify(project)
+    }
+
+    private fun isPythonPluginAvailable(): Boolean =
+        com.intellij.ide.plugins.PluginManagerCore
+            .getPlugin(
+                PluginId.getId("com.intellij.modules.python"),
+            )?.isEnabled == true ||
+            com.intellij.ide.plugins.PluginManagerCore
+                .getPlugin(
+                    PluginId.getId("PythonCore"),
+                )?.isEnabled == true
+}

--- a/src/main/kotlin/com/github/pyvenvmanage/settings/PyVenvManageSettings.kt
+++ b/src/main/kotlin/com/github/pyvenvmanage/settings/PyVenvManageSettings.kt
@@ -30,6 +30,7 @@ class PyVenvManageSettings : PersistentStateComponent<PyVenvManageSettings.Setti
         var suffix: String = "]",
         var separator: String = " - ",
         var fields: List<String> = DecorationField.entries.map { it.name },
+        var dismissedPythonWarning: Boolean = false,
     )
 
     override fun getState(): SettingsState = state
@@ -60,6 +61,12 @@ class PyVenvManageSettings : PersistentStateComponent<PyVenvManageSettings.Setti
         get() = state.fields.mapNotNull { name -> DecorationField.entries.find { it.name == name } }
         set(value) {
             state.fields = value.map { it.name }
+        }
+
+    var dismissedPythonWarning: Boolean
+        get() = state.dismissedPythonWarning
+        set(value) {
+            state.dismissedPythonWarning = value
         }
 
     fun formatDecoration(info: VenvInfo): String {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,39 +3,13 @@
     <name>PyVenv Manage 2</name>
     <vendor url="https://github.com/pyvenvmanage/PyVenvManage">pyvenvmanage</vendor>
 
-    <depends>com.intellij.modules.python</depends>
     <depends>com.intellij.modules.platform</depends>
+    <depends optional="true" config-file="pyvenvmanage-python.xml">com.intellij.modules.python</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <notificationGroup id="Python SDK change"
-                           displayType="BALLOON"/>
-        <projectViewNodeDecorator implementation="com.github.pyvenvmanage.VenvProjectViewNodeDecorator"/>
-        <applicationConfigurable
-                parentId="tools"
-                instance="com.github.pyvenvmanage.settings.PyVenvManageConfigurable"
-                id="com.github.pyvenvmanage.settings.PyVenvManageConfigurable"
-                displayName="PyVenv Manage"/>
+        <notificationGroup id="PyVenv Manage"
+                           displayType="STICKY_BALLOON"/>
+        <postStartupActivity implementation="com.github.pyvenvmanage.PythonRequiredStartupActivity"/>
     </extensions>
-
-    <actions>
-        <action
-                id="com.github.pyvenvmanage.actions.ConfigurePythonActionProject"
-                class="com.github.pyvenvmanage.actions.ConfigurePythonActionProject"
-                text="Set as Project Interpreter"
-                description="Configure this Python to be the projects interpreter."
-                icon="com.jetbrains.python.icons.PythonIcons.Python.Virtualenv"
-        >
-            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
-        </action>
-        <action
-                id="com.github.pyvenvmanage.actions.ConfigurePythonActionModule"
-                class="com.github.pyvenvmanage.actions.ConfigurePythonActionModule"
-                text="Set as Module Interpreter"
-                description="Configure this Python to be the current modules interpreter."
-                icon="com.jetbrains.python.icons.PythonIcons.Python.Virtualenv"
-        >
-            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
-        </action>
-    </actions>
 
 </idea-plugin>

--- a/src/main/resources/META-INF/pyvenvmanage-python.xml
+++ b/src/main/resources/META-INF/pyvenvmanage-python.xml
@@ -1,0 +1,33 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <notificationGroup id="Python SDK change"
+                           displayType="BALLOON"/>
+        <projectViewNodeDecorator implementation="com.github.pyvenvmanage.VenvProjectViewNodeDecorator"/>
+        <applicationConfigurable
+                parentId="tools"
+                instance="com.github.pyvenvmanage.settings.PyVenvManageConfigurable"
+                id="com.github.pyvenvmanage.settings.PyVenvManageConfigurable"
+                displayName="PyVenv Manage"/>
+    </extensions>
+
+    <actions>
+        <action
+                id="com.github.pyvenvmanage.actions.ConfigurePythonActionProject"
+                class="com.github.pyvenvmanage.actions.ConfigurePythonActionProject"
+                text="Set as Project Interpreter"
+                description="Configure this Python to be the projects interpreter."
+                icon="com.jetbrains.python.icons.PythonIcons.Python.Virtualenv"
+        >
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+        </action>
+        <action
+                id="com.github.pyvenvmanage.actions.ConfigurePythonActionModule"
+                class="com.github.pyvenvmanage.actions.ConfigurePythonActionModule"
+                text="Set as Module Interpreter"
+                description="Configure this Python to be the current modules interpreter."
+                icon="com.jetbrains.python.icons.PythonIcons.Python.Virtualenv"
+        >
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+        </action>
+    </actions>
+</idea-plugin>

--- a/src/test/kotlin/com/github/pyvenvmanage/PythonRequiredStartupActivityTest.kt
+++ b/src/test/kotlin/com/github/pyvenvmanage/PythonRequiredStartupActivityTest.kt
@@ -1,0 +1,162 @@
+package com.github.pyvenvmanage
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.Project
+
+import com.github.pyvenvmanage.settings.PyVenvManageSettings
+
+class PythonRequiredStartupActivityTest {
+    private lateinit var project: Project
+    private lateinit var notificationGroupManager: NotificationGroupManager
+    private lateinit var notificationGroup: NotificationGroup
+    private lateinit var notification: Notification
+    private lateinit var settings: PyVenvManageSettings
+
+    @BeforeEach
+    fun setUp() {
+        project = mockk(relaxed = true)
+        notificationGroupManager = mockk(relaxed = true)
+        notificationGroup = mockk(relaxed = true)
+        notification = mockk(relaxed = true)
+        settings = mockk(relaxed = true)
+
+        mockkStatic(NotificationGroupManager::class)
+        mockkStatic(PluginManagerCore::class)
+        mockkObject(PyVenvManageSettings)
+
+        every { NotificationGroupManager.getInstance() } returns notificationGroupManager
+        every { notificationGroupManager.getNotificationGroup("PyVenv Manage") } returns notificationGroup
+        every {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+        every { notification.addAction(any<NotificationAction>()) } returns notification
+        every { PyVenvManageSettings.getInstance() } returns settings
+        every { settings.dismissedPythonWarning } returns false
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(NotificationGroupManager::class)
+        unmockkStatic(PluginManagerCore::class)
+        unmockkObject(PyVenvManageSettings)
+    }
+
+    @Test
+    fun `does not show notification when python module is available`(): Unit =
+        runBlocking {
+            val pythonPlugin: IdeaPluginDescriptor = mockk(relaxed = true)
+            every { pythonPlugin.isEnabled } returns true
+            every {
+                PluginManagerCore.getPlugin(PluginId.getId("com.intellij.modules.python"))
+            } returns pythonPlugin
+
+            PythonRequiredStartupActivity().execute(project)
+
+            verify(exactly = 0) { notification.notify(any()) }
+        }
+
+    @Test
+    fun `does not show notification when PythonCore plugin is available`(): Unit =
+        runBlocking {
+            val pythonCorePlugin: IdeaPluginDescriptor = mockk(relaxed = true)
+            every { pythonCorePlugin.isEnabled } returns true
+            every { PluginManagerCore.getPlugin(PluginId.getId("com.intellij.modules.python")) } returns null
+            every { PluginManagerCore.getPlugin(PluginId.getId("PythonCore")) } returns pythonCorePlugin
+
+            PythonRequiredStartupActivity().execute(project)
+
+            verify(exactly = 0) { notification.notify(any()) }
+        }
+
+    @Test
+    fun `shows warning notification when python is not available`(): Unit =
+        runBlocking {
+            every { PluginManagerCore.getPlugin(PluginId.getId("com.intellij.modules.python")) } returns null
+            every { PluginManagerCore.getPlugin(PluginId.getId("PythonCore")) } returns null
+
+            PythonRequiredStartupActivity().execute(project)
+
+            verify {
+                notificationGroup.createNotification(
+                    "PyVenv Manage requires Python support",
+                    "Please install the Python plugin or use PyCharm for full functionality.",
+                    NotificationType.WARNING,
+                )
+            }
+            verify { notification.notify(project) }
+        }
+
+    @Test
+    fun `shows warning when python plugin exists but is disabled`(): Unit =
+        runBlocking {
+            val disabledPlugin: IdeaPluginDescriptor = mockk(relaxed = true)
+            every { disabledPlugin.isEnabled } returns false
+            every { PluginManagerCore.getPlugin(PluginId.getId("com.intellij.modules.python")) } returns disabledPlugin
+            every { PluginManagerCore.getPlugin(PluginId.getId("PythonCore")) } returns null
+
+            PythonRequiredStartupActivity().execute(project)
+
+            verify { notification.notify(project) }
+        }
+
+    @Test
+    fun `does not show notification when warning was dismissed`(): Unit =
+        runBlocking {
+            every { PluginManagerCore.getPlugin(PluginId.getId("com.intellij.modules.python")) } returns null
+            every { PluginManagerCore.getPlugin(PluginId.getId("PythonCore")) } returns null
+            every { settings.dismissedPythonWarning } returns true
+
+            PythonRequiredStartupActivity().execute(project)
+
+            verify(exactly = 0) { notification.notify(any()) }
+        }
+
+    @Test
+    fun `notification includes dont show again action`(): Unit =
+        runBlocking {
+            every { PluginManagerCore.getPlugin(PluginId.getId("com.intellij.modules.python")) } returns null
+            every { PluginManagerCore.getPlugin(PluginId.getId("PythonCore")) } returns null
+
+            PythonRequiredStartupActivity().execute(project)
+
+            verify { notification.addAction(any<NotificationAction>()) }
+        }
+
+    @Test
+    fun `dont show again action sets dismissed flag and expires notification`(): Unit =
+        runBlocking {
+            every { PluginManagerCore.getPlugin(PluginId.getId("com.intellij.modules.python")) } returns null
+            every { PluginManagerCore.getPlugin(PluginId.getId("PythonCore")) } returns null
+
+            val actionSlot = slot<NotificationAction>()
+            every { notification.addAction(capture(actionSlot)) } returns notification
+
+            PythonRequiredStartupActivity().execute(project)
+
+            val event: com.intellij.openapi.actionSystem.AnActionEvent = mockk(relaxed = true)
+            actionSlot.captured.actionPerformed(event, notification)
+
+            verify { settings.dismissedPythonWarning = true }
+            verify { notification.expire() }
+        }
+}

--- a/src/test/kotlin/com/github/pyvenvmanage/settings/PyVenvManageSettingsTest.kt
+++ b/src/test/kotlin/com/github/pyvenvmanage/settings/PyVenvManageSettingsTest.kt
@@ -174,6 +174,17 @@ class PyVenvManageSettingsTest {
     }
 
     @Test
+    fun `default dismissedPythonWarning is false`() {
+        assertEquals(false, settings.dismissedPythonWarning)
+    }
+
+    @Test
+    fun `dismissedPythonWarning can be set`() {
+        settings.dismissedPythonWarning = true
+        assertEquals(true, settings.dismissedPythonWarning)
+    }
+
+    @Test
     fun `getInstance returns settings instance`() {
         val application: Application = mockk(relaxed = true)
         val mockSettings: PyVenvManageSettings = mockk(relaxed = true)


### PR DESCRIPTION
The JetBrains Marketplace verifier incorrectly reports plugins with mandatory Python dependencies as broken for IntelliJ IDEA without Python, even affecting the plugin's availability status in PyCharm. This is a known bug tracked as MP-7540.

This change makes com.intellij.modules.python an optional dependency and moves all Python-specific extensions and actions to a separate pyvenvmanage-python.xml config file that only loads when Python is available. A startup notification now warns users if they install the plugin on an IDE without Python support.

This workaround follows the same approach used by pylint-pycharm-plugin, which was created by the same author who filed the MP-7540 bug report.