### PR TITLE
🔧 build: cap 2.3.x compatibility at IntelliJ Platform 261

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,10 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = providers.gradleProperty("pluginSinceBuild")
-            untilBuild = provider { null }
+            // The 2.3.x line targets the 2026.1 (261) Python SDK API. Build 262 changed
+            // UvSdkAdditionalData, VirtualEnvSdkFlavor, PythonSdkUtil.isVirtualEnv and the uv
+            // icon package incompatibly, so cap here and ship 262 support from the 2.4.x line.
+            untilBuild = "261.*"
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ pluginGroup=com.github.pyvenvmanage
 pluginName=PyVenv Manage 2
 pluginRepositoryUrl=https://github.com/pyvenvmanage/PyVenvManage
 pluginSinceBuild=261
-pluginVersion=2.3.1-dev
+pluginVersion=2.3.2-dev


### PR DESCRIPTION
The published `2.3.1` ships with an open `untilBuild`, so the JetBrains Marketplace serves it to IntelliJ Platform `262` (2026.2). There it is binary incompatible and fails at runtime with `NoSuchMethodError` and `NoSuchClassError`, because build `262` reshaped several Python SDK entry points the plugin depends on. The `UvSdkAdditionalData` constructor now takes `String?` paths instead of `Path?`, `VirtualEnvSdkFlavor.getInstance()` moved to `com.intellij.python.venv.sdk.flavors`, `PythonSdkUtil.isVirtualEnv(String)` is gone, and the uv icons moved to `com.intellij.python.uv.common.icons`.

Capping `untilBuild` at `261.*` keeps the `2.3.x` line scoped to the `2026.1` API it was compiled against, so the Marketplace stops offering it to `2026.2`. 🔒 Full `262` support arrives separately on the `2.4.x` line, which lets both compatibility ranges live side by side on the Marketplace.

This also bumps the development version to `2.3.2-dev` and supersedes the automated post-release bump in #183.