### PR TITLE
♻️ refactor: use public PluginManager.isPluginInstalled

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ pluginGroup=com.github.pyvenvmanage
 pluginName=PyVenv Manage 2
 pluginRepositoryUrl=https://github.com/pyvenvmanage/PyVenvManage
 pluginSinceBuild=262
-pluginVersion=2.4.0-dev
+pluginVersion=2.4.1-dev

--- a/src/main/kotlin/com/github/pyvenvmanage/PythonRequiredStartupActivity.kt
+++ b/src/main/kotlin/com/github/pyvenvmanage/PythonRequiredStartupActivity.kt
@@ -1,5 +1,7 @@
 package com.github.pyvenvmanage
 
+import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -28,20 +30,8 @@ class PythonRequiredStartupActivity : ProjectActivity {
             ).notify(project)
     }
 
-    private fun isPythonPluginAvailable(): Boolean {
-        val pythonModuleId = PluginId.getId("com.intellij.modules.python")
-        val pythonCoreId = PluginId.getId("PythonCore")
-        return (
-            com.intellij.ide.plugins.PluginManagerCore
-                .getPlugin(pythonModuleId) != null &&
-                !com.intellij.ide.plugins.PluginManagerCore
-                    .isDisabled(pythonModuleId)
-        ) ||
-            (
-                com.intellij.ide.plugins.PluginManagerCore
-                    .getPlugin(pythonCoreId) != null &&
-                    !com.intellij.ide.plugins.PluginManagerCore
-                        .isDisabled(pythonCoreId)
-            )
-    }
+    private fun isPythonPluginAvailable(): Boolean =
+        isEnabled(PluginId.getId("com.intellij.modules.python")) || isEnabled(PluginId.getId("PythonCore"))
+
+    private fun isEnabled(id: PluginId): Boolean = PluginManager.isPluginInstalled(id) && !PluginManagerCore.isDisabled(id)
 }

--- a/src/main/kotlin/com/github/pyvenvmanage/PythonRequiredStartupActivity.kt
+++ b/src/main/kotlin/com/github/pyvenvmanage/PythonRequiredStartupActivity.kt
@@ -33,5 +33,6 @@ class PythonRequiredStartupActivity : ProjectActivity {
     private fun isPythonPluginAvailable(): Boolean =
         isEnabled(PluginId.getId("com.intellij.modules.python")) || isEnabled(PluginId.getId("PythonCore"))
 
-    private fun isEnabled(id: PluginId): Boolean = PluginManager.isPluginInstalled(id) && !PluginManagerCore.isDisabled(id)
+    private fun isEnabled(id: PluginId): Boolean =
+        PluginManager.isPluginInstalled(id) && !PluginManagerCore.isDisabled(id)
 }

--- a/src/test/kotlin/com/github/pyvenvmanage/PythonRequiredStartupActivityTest.kt
+++ b/src/test/kotlin/com/github/pyvenvmanage/PythonRequiredStartupActivityTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
@@ -45,6 +45,7 @@ class PythonRequiredStartupActivityTest {
         pythonCoreId = PluginId.getId("PythonCore")
 
         mockkStatic(NotificationGroupManager::class)
+        mockkStatic(PluginManager::class)
         mockkStatic(PluginManagerCore::class)
         mockkObject(PyVenvManageSettings)
 
@@ -61,6 +62,7 @@ class PythonRequiredStartupActivityTest {
     @AfterEach
     fun tearDown() {
         unmockkStatic(NotificationGroupManager::class)
+        unmockkStatic(PluginManager::class)
         unmockkStatic(PluginManagerCore::class)
         unmockkObject(PyVenvManageSettings)
     }
@@ -68,8 +70,7 @@ class PythonRequiredStartupActivityTest {
     @Test
     fun `does not show notification when python module is available`(): Unit =
         runBlocking {
-            val pythonPlugin: IdeaPluginDescriptor = mockk(relaxed = true)
-            every { PluginManagerCore.getPlugin(pythonModuleId) } returns pythonPlugin
+            every { PluginManager.isPluginInstalled(pythonModuleId) } returns true
             every { PluginManagerCore.isDisabled(pythonModuleId) } returns false
 
             PythonRequiredStartupActivity().execute(project)
@@ -80,9 +81,8 @@ class PythonRequiredStartupActivityTest {
     @Test
     fun `does not show notification when PythonCore plugin is available`(): Unit =
         runBlocking {
-            val pythonCorePlugin: IdeaPluginDescriptor = mockk(relaxed = true)
-            every { PluginManagerCore.getPlugin(pythonModuleId) } returns null
-            every { PluginManagerCore.getPlugin(pythonCoreId) } returns pythonCorePlugin
+            every { PluginManager.isPluginInstalled(pythonModuleId) } returns false
+            every { PluginManager.isPluginInstalled(pythonCoreId) } returns true
             every { PluginManagerCore.isDisabled(pythonCoreId) } returns false
 
             PythonRequiredStartupActivity().execute(project)
@@ -93,8 +93,8 @@ class PythonRequiredStartupActivityTest {
     @Test
     fun `shows warning notification when python is not available`(): Unit =
         runBlocking {
-            every { PluginManagerCore.getPlugin(pythonModuleId) } returns null
-            every { PluginManagerCore.getPlugin(pythonCoreId) } returns null
+            every { PluginManager.isPluginInstalled(pythonModuleId) } returns false
+            every { PluginManager.isPluginInstalled(pythonCoreId) } returns false
 
             PythonRequiredStartupActivity().execute(project)
 
@@ -111,10 +111,9 @@ class PythonRequiredStartupActivityTest {
     @Test
     fun `shows warning when python plugin exists but is disabled`(): Unit =
         runBlocking {
-            val disabledPlugin: IdeaPluginDescriptor = mockk(relaxed = true)
-            every { PluginManagerCore.getPlugin(pythonModuleId) } returns disabledPlugin
+            every { PluginManager.isPluginInstalled(pythonModuleId) } returns true
             every { PluginManagerCore.isDisabled(pythonModuleId) } returns true
-            every { PluginManagerCore.getPlugin(pythonCoreId) } returns null
+            every { PluginManager.isPluginInstalled(pythonCoreId) } returns false
 
             PythonRequiredStartupActivity().execute(project)
 
@@ -124,8 +123,8 @@ class PythonRequiredStartupActivityTest {
     @Test
     fun `does not show notification when warning was dismissed`(): Unit =
         runBlocking {
-            every { PluginManagerCore.getPlugin(pythonModuleId) } returns null
-            every { PluginManagerCore.getPlugin(pythonCoreId) } returns null
+            every { PluginManager.isPluginInstalled(pythonModuleId) } returns false
+            every { PluginManager.isPluginInstalled(pythonCoreId) } returns false
             every { settings.dismissedPythonWarning } returns true
 
             PythonRequiredStartupActivity().execute(project)
@@ -136,8 +135,8 @@ class PythonRequiredStartupActivityTest {
     @Test
     fun `notification includes dont show again action`(): Unit =
         runBlocking {
-            every { PluginManagerCore.getPlugin(pythonModuleId) } returns null
-            every { PluginManagerCore.getPlugin(pythonCoreId) } returns null
+            every { PluginManager.isPluginInstalled(pythonModuleId) } returns false
+            every { PluginManager.isPluginInstalled(pythonCoreId) } returns false
 
             PythonRequiredStartupActivity().execute(project)
 
@@ -147,8 +146,8 @@ class PythonRequiredStartupActivityTest {
     @Test
     fun `dont show again action sets dismissed flag and expires notification`(): Unit =
         runBlocking {
-            every { PluginManagerCore.getPlugin(pythonModuleId) } returns null
-            every { PluginManagerCore.getPlugin(pythonCoreId) } returns null
+            every { PluginManager.isPluginInstalled(pythonModuleId) } returns false
+            every { PluginManager.isPluginInstalled(pythonCoreId) } returns false
 
             val actionSlot = slot<NotificationAction>()
             every { notification.addAction(capture(actionSlot)) } returns notification


### PR DESCRIPTION
The plugin-availability check called `PluginManagerCore.getPlugin(PluginId)`, which is `@ApiStatus.Internal` on 262 and surfaced as an internal-API usage in the verifier report. Unlike the uv/venv SDK flavor, icon, and additional-data APIs (which are internal with no public alternative), this one has a public escape hatch: `com.intellij.ide.plugins.PluginManager.isPluginInstalled(PluginId)`.

Swapping to it keeps the behavior identical. `isPluginInstalled` reports presence regardless of enablement, and the existing `PluginManagerCore.isDisabled` guard (which the verifier does not flag as internal) still narrows the result to installed-and-enabled. The check also reads more clearly now that the two plugin IDs share a small helper.

Also bumps the dev version to `2.4.1-dev`, superseding the automated #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)