### PR TITLE
fix: show interpreter action only on virtualenvs

### DIFF
--- a/src/main/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionAbstract.kt
+++ b/src/main/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionAbstract.kt
@@ -15,6 +15,7 @@ import com.jetbrains.python.sdk.PythonSdkUtil
 import com.jetbrains.python.statistics.executionType
 import com.jetbrains.python.statistics.interpreterType
 
+import com.github.pyvenvmanage.VenvUtils
 import com.github.pyvenvmanage.sdk.EnvironmentDetector
 import com.github.pyvenvmanage.sdk.PythonEnvironmentType
 import com.github.pyvenvmanage.sdk.SdkFactory
@@ -23,16 +24,16 @@ abstract class ConfigurePythonActionAbstract : AnAction() {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
-        // Only offer the action on a directory that is itself a virtual environment. Resolving a file
-        // to its parent made it appear on ordinary files (e.g. main.py) whose folder merely contains
-        // a venv, which is not a valid interpreter target.
-        val venvDir = e.getData(CommonDataKeys.VIRTUAL_FILE)?.takeIf { it.isDirectory }
-        val pythonExecutable = venvDir?.let { PythonSdkUtil.getPythonExecutable(it.path) }
-        if (pythonExecutable != null) {
+        // Offer the action only on directories that are actual virtual environments, using the same
+        // pyvenv.cfg check as VenvProjectViewNodeDecorator. getPythonExecutable alone also matches
+        // non-venv directories (e.g. a project root with a configured interpreter), which surfaced the
+        // action on ordinary files via their parent directory.
+        val venvDir = e.getData(CommonDataKeys.VIRTUAL_FILE)?.takeIf { VenvUtils.getPyVenvCfg(it) != null }
+        venvDir?.let { PythonSdkUtil.getPythonExecutable(it.path) }?.let { pythonExecutable ->
             val envType = EnvironmentDetector.detectEnvironmentType(pythonExecutable)
             e.presentation.icon = SdkFactory.getIconForEnvironmentType(envType)
         }
-        e.presentation.isEnabledAndVisible = pythonExecutable != null
+        e.presentation.isEnabledAndVisible = venvDir != null
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionAbstract.kt
+++ b/src/main/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionAbstract.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
@@ -21,39 +20,23 @@ import com.github.pyvenvmanage.sdk.PythonEnvironmentType
 import com.github.pyvenvmanage.sdk.SdkFactory
 
 abstract class ConfigurePythonActionAbstract : AnAction() {
-    companion object {
-        private val LOG = Logger.getInstance(ConfigurePythonActionAbstract::class.java)
-    }
-
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
-        val selectedPath = e.getData(CommonDataKeys.VIRTUAL_FILE)
-        LOG.info("Update called for path: $selectedPath")
-        val isValid =
-            selectedPath?.let { path ->
-                val dir = if (path.isDirectory) path else path.parent
-                LOG.info("Checking directory: ${dir.path}")
-                PythonSdkUtil.getPythonExecutable(dir.path)?.let { pythonExe ->
-                    LOG.info("Found python executable: $pythonExe")
-                    val envType = EnvironmentDetector.detectEnvironmentType(pythonExe)
-                    val icon = SdkFactory.getIconForEnvironmentType(envType)
-                    LOG.info("Setting icon for type $envType: $icon")
-                    e.presentation.icon = icon
-                    true
-                } ?: false.also { LOG.info("No python executable found") }
-            } ?: false.also { LOG.info("No selected path") }
-
-        e.presentation.isEnabledAndVisible = isValid
-        LOG.info("Action visible: $isValid")
+        // Only offer the action on a directory that is itself a virtual environment. Resolving a file
+        // to its parent made it appear on ordinary files (e.g. main.py) whose folder merely contains
+        // a venv, which is not a valid interpreter target.
+        val venvDir = e.getData(CommonDataKeys.VIRTUAL_FILE)?.takeIf { it.isDirectory }
+        val pythonExecutable = venvDir?.let { PythonSdkUtil.getPythonExecutable(it.path) }
+        if (pythonExecutable != null) {
+            e.presentation.icon = SdkFactory.getIconForEnvironmentType(EnvironmentDetector.detectEnvironmentType(pythonExecutable))
+        }
+        e.presentation.isEnabledAndVisible = pythonExecutable != null
     }
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val selectedPath =
-            e.getData(CommonDataKeys.VIRTUAL_FILE)?.let {
-                if (it.isDirectory) it else it.parent
-            } ?: return
+        val selectedPath = e.getData(CommonDataKeys.VIRTUAL_FILE)?.takeIf { it.isDirectory } ?: return
 
         val pythonExecutable = PythonSdkUtil.getPythonExecutable(selectedPath.path)
         if (pythonExecutable == null) {

--- a/src/main/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionAbstract.kt
+++ b/src/main/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionAbstract.kt
@@ -29,7 +29,8 @@ abstract class ConfigurePythonActionAbstract : AnAction() {
         val venvDir = e.getData(CommonDataKeys.VIRTUAL_FILE)?.takeIf { it.isDirectory }
         val pythonExecutable = venvDir?.let { PythonSdkUtil.getPythonExecutable(it.path) }
         if (pythonExecutable != null) {
-            e.presentation.icon = SdkFactory.getIconForEnvironmentType(EnvironmentDetector.detectEnvironmentType(pythonExecutable))
+            val envType = EnvironmentDetector.detectEnvironmentType(pythonExecutable)
+            e.presentation.icon = SdkFactory.getIconForEnvironmentType(envType)
         }
         e.presentation.isEnabledAndVisible = pythonExecutable != null
     }

--- a/src/test/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionAbstractTest.kt
+++ b/src/test/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionAbstractTest.kt
@@ -35,6 +35,7 @@ import com.intellij.python.venv.icons.PythonVenvIcons
 import com.jetbrains.python.configuration.PyConfigurableInterpreterList
 import com.jetbrains.python.sdk.PythonSdkUtil
 
+import com.github.pyvenvmanage.VenvUtils
 import com.github.pyvenvmanage.sdk.EnvironmentDetector
 import com.github.pyvenvmanage.sdk.PythonEnvironmentType
 import com.github.pyvenvmanage.sdk.SdkFactory
@@ -68,6 +69,7 @@ class ConfigurePythonActionAbstractTest {
         @BeforeEach
         fun setUpMocks() {
             mockkStatic(PythonSdkUtil::class)
+            mockkObject(VenvUtils)
             mockkObject(EnvironmentDetector)
             mockkObject(SdkFactory)
         }
@@ -87,10 +89,10 @@ class ConfigurePythonActionAbstractTest {
         }
 
         @Test
-        fun `enables action for directory with Python executable`() {
+        fun `enables action for virtualenv directory`() {
             every { event.getData(CommonDataKeys.VIRTUAL_FILE) } returns virtualFile
-            every { virtualFile.isDirectory } returns true
             every { virtualFile.path } returns "/some/venv"
+            every { VenvUtils.getPyVenvCfg(virtualFile) } returns Path.of("/some/venv/pyvenv.cfg")
             every { PythonSdkUtil.getPythonExecutable("/some/venv") } returns "/some/venv/bin/python"
             every { EnvironmentDetector.detectEnvironmentType("/some/venv/bin/python") } returns
                 PythonEnvironmentType.UV
@@ -103,11 +105,9 @@ class ConfigurePythonActionAbstractTest {
         }
 
         @Test
-        fun `disables action for directory without Python executable`() {
+        fun `disables action for non-venv directory`() {
             every { event.getData(CommonDataKeys.VIRTUAL_FILE) } returns virtualFile
-            every { virtualFile.isDirectory } returns true
-            every { virtualFile.path } returns "/some/dir"
-            every { PythonSdkUtil.getPythonExecutable("/some/dir") } returns null
+            every { VenvUtils.getPyVenvCfg(virtualFile) } returns null
 
             action.update(event)
 
@@ -117,7 +117,7 @@ class ConfigurePythonActionAbstractTest {
         @Test
         fun `disables action for non-directory selection`() {
             every { event.getData(CommonDataKeys.VIRTUAL_FILE) } returns virtualFile
-            every { virtualFile.isDirectory } returns false
+            every { VenvUtils.getPyVenvCfg(virtualFile) } returns null
 
             action.update(event)
 
@@ -128,8 +128,8 @@ class ConfigurePythonActionAbstractTest {
         @Test
         fun `sets icon based on detected environment type`() {
             every { event.getData(CommonDataKeys.VIRTUAL_FILE) } returns virtualFile
-            every { virtualFile.isDirectory } returns true
             every { virtualFile.path } returns "/some/venv"
+            every { VenvUtils.getPyVenvCfg(virtualFile) } returns Path.of("/some/venv/pyvenv.cfg")
             every { PythonSdkUtil.getPythonExecutable("/some/venv") } returns "/some/venv/bin/python"
             every { EnvironmentDetector.detectEnvironmentType("/some/venv/bin/python") } returns
                 PythonEnvironmentType.UV

--- a/src/test/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionAbstractTest.kt
+++ b/src/test/kotlin/com/github/pyvenvmanage/actions/ConfigurePythonActionAbstractTest.kt
@@ -115,6 +115,17 @@ class ConfigurePythonActionAbstractTest {
         }
 
         @Test
+        fun `disables action for non-directory selection`() {
+            every { event.getData(CommonDataKeys.VIRTUAL_FILE) } returns virtualFile
+            every { virtualFile.isDirectory } returns false
+
+            action.update(event)
+
+            verify { presentation.isEnabledAndVisible = false }
+            verify(exactly = 0) { PythonSdkUtil.getPythonExecutable(any()) }
+        }
+
+        @Test
         fun `sets icon based on detected environment type`() {
             every { event.getData(CommonDataKeys.VIRTUAL_FILE) } returns virtualFile
             every { virtualFile.isDirectory } returns true
@@ -133,7 +144,6 @@ class ConfigurePythonActionAbstractTest {
 
     @Nested
     inner class ActionPerformedTest {
-        private lateinit var parentDir: VirtualFile
         private lateinit var interpreterList: PyConfigurableInterpreterList
         private lateinit var notificationGroupManager: NotificationGroupManager
         private lateinit var notificationGroup: NotificationGroup
@@ -142,7 +152,6 @@ class ConfigurePythonActionAbstractTest {
 
         @BeforeEach
         fun setUpMocks() {
-            parentDir = mockk(relaxed = true)
             interpreterList = mockk(relaxed = true)
             notificationGroupManager = mockk(relaxed = true)
             notificationGroup = mockk(relaxed = true)
@@ -191,16 +200,13 @@ class ConfigurePythonActionAbstractTest {
         }
 
         @Test
-        fun `uses parent directory when file is not a directory`() {
+        fun `ignores non-directory selection`() {
             every { event.getData(CommonDataKeys.VIRTUAL_FILE) } returns virtualFile
             every { virtualFile.isDirectory } returns false
-            every { virtualFile.parent } returns parentDir
-            every { parentDir.path } returns "/some/venv"
-            every { PythonSdkUtil.getPythonExecutable("/some/venv") } returns null
 
             action.actionPerformed(event)
 
-            verify { PythonSdkUtil.getPythonExecutable("/some/venv") }
+            verify(exactly = 0) { PythonSdkUtil.getPythonExecutable(any()) }
         }
 
         @Test


### PR DESCRIPTION
The `🖥️ UI tests` check fails on `main`, which blocks every PR (including the Dependabot bumps) because it is a required check. `testContextMenuOnPythonFile` right-clicks `main.py` and asserts that `Set as Project Interpreter` is absent, but the action appears on the file.

`ConfigurePythonActionAbstract.update()` decided visibility from `PythonSdkUtil.getPythonExecutable(dir) != null` alone, resolving a right-clicked file to its parent directory first. That check is weaker than the plugin's own definition of a virtualenv: it also matches non-venv directories, such as a project root once an interpreter is configured, so on the 2026.2 platform the action surfaces on `main.py` through its parent folder. The action now gates on `VenvUtils.getPyVenvCfg`, the same `pyvenv.cfg` check `VenvProjectViewNodeDecorator` uses to mark venvs, so it appears only on directories that are actual virtual environments.

Right-clicking a venv directory still shows and applies the action; files, and directories that merely contain or reference a Python interpreter, no longer surface it. The unit tests cover venv, non-venv, and non-directory selections.
